### PR TITLE
Refactor: Use .env file for configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Ollama API configuration
+OLLAMA_HOST=http://host.docker.internal:11434
+
+# Folder structure for image sorting
+INPUT_FOLDER=images
+BAD_QUALITY_FOLDER_NAME=bad_quality
+OK_QUALITY_FOLDER_NAME=ok
+
+# Model name for image classification
+MODEL_NAME=gemma3:4b

--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ sort-images-with-ollama
 3. **Install Dependencies**
    - The development container will automatically install the required Python dependencies specified in the `Dockerfile`.
 
+## Configuration
+
+This project uses a `.env` file for configuration. To get started:
+
+1.  Copy the example configuration file:
+    ```bash
+    cp .env.example .env
+    ```
+2.  Customize the values in the `.env` file as needed. The available variables are:
+    *   `OLLAMA_HOST`: The URL of the Ollama API. Defaults to `http://host.docker.internal:11434`.
+    *   `INPUT_FOLDER`: The directory where images to be sorted are located. Defaults to `images`.
+    *   `BAD_QUALITY_FOLDER_NAME`: The name of the folder to store bad quality images. Defaults to `bad_quality`.
+    *   `OK_QUALITY_FOLDER_NAME`: The name of the folder to store good quality images. Defaults to `ok`.
+    *   `MODEL_NAME`: The name of the Ollama model to use for image classification. Defaults to `gemma3:4b`.
+
 ## Usage
 
 1. Place the images you want to classify in the `images` directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ smmap==5.0.2
 sniffio==1.3.1
 typing-inspection==0.4.1
 typing_extensions==4.13.2
+python-dotenv

--- a/sort-images.py
+++ b/sort-images.py
@@ -4,15 +4,19 @@ from pathlib import Path
 from ollama import chat
 from ollama._types import Image
 from ollama import Client
+from dotenv import load_dotenv
 
-client = Client(
-    host='http://host.docker.internal:11434'
-)
+load_dotenv()
+
+OLLAMA_HOST = os.getenv('OLLAMA_HOST', 'http://host.docker.internal:11434')
+client = Client(host=OLLAMA_HOST)
 
 # Paths
-INPUT_FOLDER = 'images'
-BAD_FOLDER = os.path.join(INPUT_FOLDER, 'bad_quality')
-OK_FOLDER = os.path.join(INPUT_FOLDER, 'ok')
+INPUT_FOLDER = os.getenv('INPUT_FOLDER', 'images')
+BAD_QUALITY_FOLDER_NAME = os.getenv('BAD_QUALITY_FOLDER_NAME', 'bad_quality')
+BAD_FOLDER = os.path.join(INPUT_FOLDER, BAD_QUALITY_FOLDER_NAME)
+OK_QUALITY_FOLDER_NAME = os.getenv('OK_QUALITY_FOLDER_NAME', 'ok')
+OK_FOLDER = os.path.join(INPUT_FOLDER, OK_QUALITY_FOLDER_NAME)
 
 print("🔄 Sorting images...")
 
@@ -21,7 +25,7 @@ os.makedirs(BAD_FOLDER, exist_ok=True)
 os.makedirs(OK_FOLDER, exist_ok=True)
 
 # Model name – use a vision-capable one
-MODEL = 'gemma3:4b'  # Working great
+MODEL = os.getenv('MODEL_NAME', 'gemma3:4b')  # Working great
 
 # MODEL = 'llava:latest' # Not working, dosent follow instructions
 


### PR DESCRIPTION
I moved hardcoded paths and model names to a .env file to allow for easier customization.

Key changes:
- I added `python-dotenv` to `requirements.txt` for managing environment variables.
- I created a `.env.example` file to provide a template for you.
- I modified `sort-images.py` to load `OLLAMA_HOST`, `INPUT_FOLDER`, `BAD_QUALITY_FOLDER_NAME`, `OK_QUALITY_FOLDER_NAME`, and `MODEL_NAME` from environment variables, with sensible defaults.
- I updated `README.md` to explain the new configuration method.

This change allows you to customize the application's behavior without modifying the source code directly.